### PR TITLE
Fix crash when computing move power of "Atout"

### DIFF
--- a/ironmon_tracker/ui/MainScreen.lua
+++ b/ironmon_tracker/ui/MainScreen.lua
@@ -433,7 +433,7 @@ local function MainScreen(initialSettings, initialTracker, initialProgram)
             local moveFrame = ui.moveInfoFrames[index]
             local damage =
                 MoveUtils.calculateVariableDamage(
-                name,
+                moveID,
                 movePPs,
                 index,
                 currentPokemon,

--- a/ironmon_tracker/utils/MoveUtils.lua
+++ b/ironmon_tracker/utils/MoveUtils.lua
@@ -148,7 +148,17 @@ function MoveUtils.getMoveHeader(pokemon)
     return header
 end
 
-function MoveUtils.calculateVariableDamage(moveName, movePPs, index, currentPokemon, opposingPokemon, isEnemy, inBattle)
+function MoveUtils.calculateVariableDamage(moveId, movePPs, index, currentPokemon, opposingPokemon, isEnemy, inBattle)
+    local flailId = 175
+    local reversalId = 179
+    local waterSpoutId = 323
+    local eruptionId = 284
+    local trumpCardId = 376
+    local heatCrashId = 535
+    local heavySlamId = 484
+    local punishmentId = 386
+    local grassKnotId = 447
+    local lowKickId = 67
     local lowHPCalcEntry = {
         requirement = not isEnemy,
         calcFunction = function()
@@ -174,30 +184,30 @@ function MoveUtils.calculateVariableDamage(moveName, movePPs, index, currentPoke
         end
     }
     local moveNamesToCalcFunctions = {
-        ["Flail"] = lowHPCalcEntry,
-        ["Reversal"] = lowHPCalcEntry,
-        ["Water Spout"] = highHPCalcEntry,
-        ["Eruption"] = highHPCalcEntry,
-        ["Trump Card"] = {
+        [flailId] = lowHPCalcEntry,
+        [reversalId] = lowHPCalcEntry,
+        [waterSpoutId] = highHPCalcEntry,
+        [eruptionId] = highHPCalcEntry,
+        [trumpCardId] = {
             requirement = true,
             calcFunction = function(movePP)
                 return MoveUtils.calculateTrumpCardPower(movePP)
             end
         },
-        ["Heat Crash"] = weightDifferenceEntry,
-        ["Heavy Slam"] = weightDifferenceEntry,
-        ["Punishment"] = {
+        [heatCrashId] = weightDifferenceEntry,
+        [heavySlamId] = weightDifferenceEntry,
+        [punishmentId] = {
             requirement = inBattle and opposingPokemon ~= nil,
             calcFunction = function()
                 return MoveUtils.calculatePunishmentPower(opposingPokemon)
             end
         },
-        ["Grass Knot"] = weightBasedEntry,
-        ["Low Kick"] = weightBasedEntry
+        [grassKnotId] = weightBasedEntry,
+        [lowKickId] = weightBasedEntry
     }
-    local entry = moveNamesToCalcFunctions[moveName]
+    local entry = moveNamesToCalcFunctions[moveId]
     if entry then
-        if moveName ~= "Trump Card" then
+        if moveId ~= trumpCardId then
             if entry.requirement then
                 return entry.calcFunction()
             end


### PR DESCRIPTION
The logic computing power of moves with variable power was based on move names and not move IDs. Those name were not translated, so it didn't work well with the french name of moves.
The function computing power of "Atout" (Trump card) needs the current PP value, but it was called without argument, resulting in a crash of the tracker if a pokemon had this move and the option to compute power of variable move was enabled.
To correct this while avoiding the issue of slight name changes of the same move bewteen gen 4 and 5 (Gicledo and Giclédo for instance), the logic is now based of the move id instead of name.

Note: Crash reproduced with version 6.3.7.5 but with 6.3.8.1 even with the option to compute variable power moves, it did not compute the value and did not crash. I'm also not fully sure how it was working before for the moves others than "Atout" that also had the english name in the code logic yet the computation worked. I did not see any change related to this between the 2 version but maybe I missed something (in merge commit maybe?)

Tested my change with Atout and Gicledo on HGSS, not tested all the other moves but I double checked I put the correct move IDs for each